### PR TITLE
fix an issue in case there is securitySchemes section in the components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 dependency-reduced-pom.xml
 openapi-bundler.iml
+.DS_Store

--- a/src/main/java/com/networknt/openapi/Bundler.java
+++ b/src/main/java/com/networknt/openapi/Bundler.java
@@ -143,10 +143,15 @@ public class Bundler {
 				if ((componentsMap != null) && (componentsMap.get("schemas") != null)) {
 					schemasMap = (Map<String, Object>) componentsMap.get("schemas");
 				} else {
-					componentsMap = new HashMap<String, Object>();
-					map.put("components", componentsMap);
-					schemasMap = new HashMap<String, Object>();
-					componentsMap.put("schemas", schemasMap);
+					if (componentsMap==null) {
+						componentsMap = new HashMap<String, Object>();
+						map.put("components", componentsMap);
+						schemasMap = new HashMap<String, Object>();
+						componentsMap.put("schemas", schemasMap);
+					} else if (componentsMap.get("schemas")==null) {
+						schemasMap = new HashMap<String, Object>();
+						componentsMap.put("schemas", schemasMap);
+					}
 				}
 
 				schemasMap.putAll(definitions);


### PR DESCRIPTION
Dan, we use this tools in several projects already. It works very good.

But in case if we put the "securitySchemas" in the components section in the main input source yaml file. After we run the tool, the securitySchemas mapping will disappear:

components:
  securitySchemes:
    petstore_auth:
      type: oauth2
      description: This API uses OAuth 2 with the client credential grant flow.
      flows:
        clientCredentials:
          tokenUrl: 'https://localhost:6882/token'
          scopes:
            'write:pets': modify pets in your account
            'read:pets': read your pets


I added a fix in the PR, please take a look and verify.

Thanks,